### PR TITLE
Bump up the maximum number of attributes items support.

### DIFF
--- a/extension/extension.cpp
+++ b/extension/extension.cpp
@@ -70,6 +70,9 @@ void *g_pVTable_Attributes;
 HandleType_t g_ScriptedItemOverrideHandleType = 0;
 TScriptedItemOverrideTypeHandler g_ScriptedItemOverrideHandler;
 
+// the maximum number of attributes that an item can support
+const int g_MaxAttributes = 20;
+
 sp_nativeinfo_t g_ExtensionNatives[] =
 {
 	{ "TF2Items_GiveNamedItem",		TF2Items_GiveNamedItem },
@@ -848,9 +851,9 @@ static cell_t TF2Items_SetNumAttributes(IPluginContext *pContext, const cell_t *
 
 	if (pScriptedItemOverride != NULL)
 	{
-		if (params[2] < 0 || params[2] > 15)
+		if (params[2] < 0 || params[2] >= g_MaxAttributes)
 		{
-			return pContext->ThrowNativeError("Attributes size out of bounds: %i [0 ... 15]", params[2]);
+			return pContext->ThrowNativeError("Attributes size out of bounds: %i [0 ... %i]", params[2], g_MaxAttributes - 1);
 		}
 
 		pScriptedItemOverride->m_iCount = params[2];
@@ -877,9 +880,9 @@ static cell_t TF2Items_SetAttribute(IPluginContext *pContext, const cell_t *para
 
 	if (pScriptedItemOverride != NULL)
 	{
-		if (params[2] < 0 || params[2] > 15)
+		if (params[2] < 0 || params[2] >= g_MaxAttributes)
 		{
-			return pContext->ThrowNativeError("Attribute index out of bounds: %i [0 ... 15]", params[2]);
+			return pContext->ThrowNativeError("Attribute index out of bounds: %i [0 ... %i]", params[2], g_MaxAttributes - 1);
 		}
 		
 		if (params[3] == 0)
@@ -902,9 +905,9 @@ static cell_t TF2Items_GetAttributeId(IPluginContext *pContext, const cell_t *pa
 
 	if (pScriptedItemOverride != NULL)
 	{
-		if (params[2] < 0 || params[2] > 15)
+		if (params[2] < 0 || params[2] >= g_MaxAttributes)
 		{
-			return pContext->ThrowNativeError("Attribute index out of bounds: %i [0 ... 15]", params[2]);
+			return pContext->ThrowNativeError("Attribute index out of bounds: %i [0 ... %i]", params[2], g_MaxAttributes - 1);
 		}
 
 		return pScriptedItemOverride->m_Attributes[params[2]].m_iAttributeDefinitionIndex;
@@ -919,9 +922,9 @@ static cell_t TF2Items_GetAttributeValue(IPluginContext *pContext, const cell_t 
 
 	if (pScriptedItemOverride != NULL)
 	{
-		if (params[2] < 0 || params[2] > 15)
+		if (params[2] < 0 || params[2] >= g_MaxAttributes)
 		{
-			return pContext->ThrowNativeError("Attribute index out of bounds: %i [0 ... 15]", params[2]);
+			return pContext->ThrowNativeError("Attribute index out of bounds: %i [0 ... %i]", params[2], g_MaxAttributes - 1);
 		}
 
 		return sp_ftoc(pScriptedItemOverride->m_Attributes[params[2]].m_flValue);


### PR DESCRIPTION
TF2 bumped up the maximum number of attributes that items support:

```
 Table: m_AttributeList (offset 2592) (type DT_AttributeList)
  Table: m_Attributes (offset 0) (type _ST_m_Attributes_20)
   Table: lengthproxy (offset 0) (type _LPT_m_Attributes_20)
    Member: lengthprop20 (offset 0) (type integer) (bits 5) (Unsigned)
```

Didn't go through the effort of figuring out the maximum number from the DT, that could be a future improvement though.