### PR TITLE
Native retval fix, syntax update, and formatting

### DIFF
--- a/pawn/tf2items.inc
+++ b/pawn/tf2items.inc
@@ -7,11 +7,11 @@
 
 // ====[ CONSTANTS ]===========================================================
 #define OVERRIDE_CLASSNAME		(1 << 0)	// Item will override the entity's classname.
-#define OVERRIDE_ITEM_DEF			(1 << 1)	// Item will override the item's definition index.
+#define OVERRIDE_ITEM_DEF		(1 << 1)	// Item will override the item's definition index.
 #define OVERRIDE_ITEM_LEVEL		(1 << 2)	// Item will override the entity's level.
-#define OVERRIDE_ITEM_QUALITY		(1 << 3)	// Item will override the entity's quality.
+#define OVERRIDE_ITEM_QUALITY	(1 << 3)	// Item will override the entity's quality.
 #define OVERRIDE_ATTRIBUTES		(1 << 4)	// Item will override the attributes for the item with the given ones.
-#define OVERRIDE_ALL				(0b11111)	// Magically enables all the other flags.
+#define OVERRIDE_ALL			(0b11111)	// Magically enables all the other flags.
 
 #define PRESERVE_ATTRIBUTES		(1 << 5)
 #define FORCE_GENERATION		(1 << 6)
@@ -34,7 +34,7 @@
  * so please make sure you fill out everything: Classname, item definition index,
  * quality, level and attributes.
  * 
- * @param client	Client that the item will be generated for.
+ * @param client		Client that the item will be generated for.
  * @param item		Handle to the TF2Items object that we'll be operating with.
  * @return			Entity index of the newly created item.
  */
@@ -46,7 +46,7 @@ native int TF2Items_GiveNamedItem(int client, Handle item);
  * with GiveNamedItem. Remember to free the object with CloseHandle()
  *
  * @param flags		Flags used to specify what to override.
- * @return				Handle to the TFItems object.
+ * @return			Handle to the TFItems object.
  */
 native Handle TF2Items_CreateItem(int flags);
 
@@ -55,7 +55,7 @@ native Handle TF2Items_CreateItem(int flags);
  * Use the OVERRIDE_ defines to set what you will be changing.
  *
  * @param item			Handle to the TF2Items object that we'll be operating with.
- * @param flags		Flags used to specify what to override.
+ * @param flags			Flags used to specify what to override.
  * @noreturn
  */
 native void TF2Items_SetFlags(Handle item, int flags);
@@ -63,7 +63,7 @@ native void TF2Items_SetFlags(Handle item, int flags);
 /**
  * Sets the new entity classname used for the item's entity.
  *
- * @param item				Handle to the TF2Items object that we'll be operating with.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
  * @param classname		New classname to use for the entity.
  * @noreturn
  */
@@ -74,8 +74,8 @@ native void TF2Items_SetClassname(Handle item, char[] classname);
  * weapon/hat/item has an unique definition index. Find these out in the
  * game_items.txt
  * 
- * @param item				Handle to the TF2Items object that we'll be operating with.
- * @param itemDefIndex		New definition index.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @param itemDefIndex	New definition index.
  * @noreturn
  */
 native void TF2Items_SetItemIndex(Handle item, int itemDefIndex);
@@ -84,7 +84,7 @@ native void TF2Items_SetItemIndex(Handle item, int itemDefIndex);
  * Sets the item's quality value, wich determines what color will be used for
  * the item name. Valid values are from 0 to 9.
  * 
- * @param item					Handle to the TF2Items object that we'll be operating with.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
  * @param quality		New item quality.
  * @noreturn
  */
@@ -93,8 +93,8 @@ native void TF2Items_SetQuality(Handle item, int quality);
 /**
  * Sets the item's level value. This value can range from 0 to 127.
  * 
- * @param item				Handle to the TF2Items object that we'll be operating with.
- * @param level		New item level.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @param level			New item level.
  * @noreturn
  */
 native void TF2Items_SetLevel(Handle item, int level);
@@ -103,7 +103,7 @@ native void TF2Items_SetLevel(Handle item, int level);
  * Sets the number of attributes that will be used on the item. The maximum
  * number of attributes that can be allocated ranges from 0 to 15.
  * 
- * @param item					Handle to the TF2Items object that we'll be operating with.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
  * @param attributes		Number of attributes.
  * @noreturn
  */
@@ -113,10 +113,10 @@ native void TF2Items_SetNumAttributes(Handle item, int attributes);
  * Setups the given attribute index to use the attribute and values specified
  * with iAttribDefIndex and flValue. Remember the iSlotIndex ranges from 0 to 15.
  * 
- * @param item					Handle to the TF2Items object that we'll be operating with.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
  * @param slot			The attribute slot index, ranges from 0 to 15.
  * @param attribute		The attribute definition index, as it appears on game_items.txt.
- * @param value				The value assigned to the attribute (how much health, damage, etc.).
+ * @param value			The value assigned to the attribute (how much health, damage, etc.).
  * @noreturn
  */
 native void TF2Items_SetAttribute(Handle item, int slot, int attribute, float value);
@@ -125,24 +125,24 @@ native void TF2Items_SetAttribute(Handle item, int slot, int attribute, float va
  * Retrieves the flags used to determine what the item will override on the
  * GiveNamedItem call.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			Returns the flags used by the item.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @return				Returns the flags used by the item.
  */
 native int TF2Items_GetFlags(Handle item);
 
 /**
  * Gets the entity classname we'll use for the item.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			New classname to use for the entity.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @return				New classname to use for the entity.
  */
 native void TF2Items_GetClassname(Handle item, char[] dest, int size);
 
 /**
  * Gets the new item definition index we'll use to override.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			New definition index.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @return				New definition index.
  */
 native int TF2Items_GetItemIndex(Handle item); 
 
@@ -151,16 +151,16 @@ native int TF2Items_GetItemIndex(Handle item);
  * the item name. Valid values are from 0 to 9. But if set to 0 and attributes
  * are also changed, this value will be overridden to 9
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			New entity quality.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @return				New entity quality.
  */
 native int TF2Items_GetQuality(Handle item); 
 
 /**
  * Gets the item's level value. This value can range from 0 to 127.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			New entity level.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @return				New entity level.
  */
 native int TF2Items_GetLevel(Handle item);
 
@@ -168,8 +168,8 @@ native int TF2Items_GetLevel(Handle item);
  * Gets the number of attributes that will be used on the item. The maximum
  * number of attributes that can be allocated ranges from 0 to 15.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			Number of attributes.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @return				Number of attributes.
  */
 native int TF2Items_GetNumAttributes(Handle item);
 
@@ -177,8 +177,8 @@ native int TF2Items_GetNumAttributes(Handle item);
  * Retrieves the attribute definition index used at the specified index on the
  * item object. Remember the iSlotIndex ranges from 0 to 15.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			The attribute definition index to use.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @return				The attribute definition index to use.
  */
 native int TF2Items_GetAttributeId(Handle item, int slot);
 
@@ -186,8 +186,8 @@ native int TF2Items_GetAttributeId(Handle item, int slot);
  * Retrieves the value used for the attribute at the specified index on the item
  * object. Remember the iSlotIndex ranges from 0 to 15.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			The attribute value to use.
+ * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @return				The attribute value to use.
  */
 native float TF2Items_GetAttributeValue(Handle item, int slot); 
 
@@ -199,12 +199,12 @@ native float TF2Items_GetAttributeValue(Handle item, int slot);
  * Return Plugin_Handled to stop the item being given to the player.
  * Make sure the client gets atleast one weapon.
  *
- * @param client				Client Index.
- * @param classname				The classname of the entity that will be generated.
+ * @param client	Client Index.
+ * @param classname		The classname of the entity that will be generated.
  * @param itemDefIndex	Item definition index.
- * @param item					Handle to a TF2Item object wich describes what values will be overriden.
+ * @param item			Handle to a TF2Item object wich describes what values will be overriden.
  */
-forward Action TF2Items_OnGiveNamedItem(int client, char[] classname, int itemDefIndex, Handle &item);
+forward Action TF2Items_OnGiveNamedItem(int client, char[] classname, int itemDefIndex, Handle& item);
 
 forward int TF2Items_OnGiveNamedItem_Post(int client, char[] classname, int itemDefIndex, int level, int quality, int entity);
 
@@ -222,34 +222,34 @@ public Extension __ext_tf2items =
 		required = 0,
 	#endif
 }
-	
+
 /**
 * I'll just leave this here...
 * 
-* _(º< _(º< _(º< _(º< _(º< _(º< _(º< _(º< _(º< 
+* _(Âº< _(Âº< _(Âº< _(Âº< _(Âº< _(Âº< _(Âº< _(Âº< _(Âº< 
 * \__) \__) \__) \__) \__) \__) \__) \__) \__) 
 *                     .  .
 *                    // //  __
-*         __  ______||_//_.´.´
-*       _/__`´            ¯ `
+*         __  ______||_//_.Â´.Â´
+*       _/__`Â´            Â¯ `
 *      /  / _          _     \
-*     /  /( · )      ( · )    |
-*    /  |   ¯     __   ¯    _/\/|
-*   |    \  ___.-´  `-.___  \   /
-*    \    \(     ` ´      `)|   \
+*     /  /( Â· )      ( Â· )    |
+*    /  |   Â¯     __   Â¯    _/\/|
+*   |    \  ___.-Â´  `-.___  \   /
+*    \    \(     ` Â´      `)|   \
 *     \     )              //     \
 *      \/  /              | |     |
 *     /   /               | |     |
-*    ·   |                |  \___/
+*    Â·   |                |  \___/
 *    |    \_            _/      \  ____
-*    ·      `----------´         |´    \
-*     \                         /    _·´
-*      \                       /  _-´ 
-*        `-._               _·´-´
-*        _.-´`---________--´ \ 
-*       ´-.-. _--·   / .   ._ \
-*            ´       `´ `·´  `´
-* >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ 
+*    Â·      `----------Â´         |Â´    \
+*     \                         /    _Â·Â´
+*      \                       /  _-Â´ 
+*        `-._               _Â·Â´-Â´
+*        _.-Â´`---________--Â´ \ 
+*       Â´-.-. _--Â·   / .   ._ \
+*            Â´       `Â´ `Â·Â´  `Â´
+* >Âº)_ >Âº)_ >Âº)_ >Âº)_ >Âº)_ >Âº)_ >Âº)_ >Âº)_ >Âº)_ 
 * (__/ (__/ (__/ (__/ (__/ (__/ (__/ (__/ (__/ 
 * 
 */

--- a/pawn/tf2items.inc
+++ b/pawn/tf2items.inc
@@ -6,15 +6,15 @@
 #include <tf2>
 
 // ====[ CONSTANTS ]===========================================================
-#define OVERRIDE_CLASSNAME		(1 << 0)	// Item will override the entity's classname.
-#define OVERRIDE_ITEM_DEF		(1 << 1)	// Item will override the item's definition index.
-#define OVERRIDE_ITEM_LEVEL		(1 << 2)	// Item will override the entity's level.
-#define OVERRIDE_ITEM_QUALITY	(1 << 3)	// Item will override the entity's quality.
-#define OVERRIDE_ATTRIBUTES		(1 << 4)	// Item will override the attributes for the item with the given ones.
-#define OVERRIDE_ALL			(0b11111)	// Magically enables all the other flags.
+#define OVERRIDE_CLASSNAME    (1 << 0)  // Item will override the entity's classname.
+#define OVERRIDE_ITEM_DEF     (1 << 1)  // Item will override the item's definition index.
+#define OVERRIDE_ITEM_LEVEL   (1 << 2)  // Item will override the entity's level.
+#define OVERRIDE_ITEM_QUALITY (1 << 3)  // Item will override the entity's quality.
+#define OVERRIDE_ATTRIBUTES   (1 << 4)  // Item will override the attributes for the item with the given ones.
+#define OVERRIDE_ALL          (0b11111) // Magically enables all the other flags.
 
-#define PRESERVE_ATTRIBUTES		(1 << 5)
-#define FORCE_GENERATION		(1 << 6)
+#define PRESERVE_ATTRIBUTES   (1 << 5)
+#define FORCE_GENERATION      (1 << 6)
 
 // ====[ NATIVES ]=============================================================
 
@@ -34,9 +34,9 @@
  * so please make sure you fill out everything: Classname, item definition index,
  * quality, level and attributes.
  * 
- * @param client		Client that the item will be generated for.
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			Entity index of the newly created item.
+ * @param client          Client that the item will be generated for.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                Entity index of the newly created item.
  */
 native int TF2Items_GiveNamedItem(int client, Handle item);
 
@@ -45,8 +45,8 @@ native int TF2Items_GiveNamedItem(int client, Handle item);
  * item before it's given to the client, or to create a new completely new one
  * with GiveNamedItem. Remember to free the object with CloseHandle()
  *
- * @param flags		Flags used to specify what to override.
- * @return			Handle to the TFItems object.
+ * @param flags           Flags used to specify what to override.
+ * @return                Handle to the TFItems object.
  */
 native Handle TF2Items_CreateItem(int flags);
 
@@ -54,8 +54,8 @@ native Handle TF2Items_CreateItem(int flags);
  * Sets the flags to determine what the item will override on the GiveNamedItem.
  * Use the OVERRIDE_ defines to set what you will be changing.
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @param flags			Flags used to specify what to override.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param flags           Flags used to specify what to override.
  * @noreturn
  */
 native void TF2Items_SetFlags(Handle item, int flags);
@@ -63,8 +63,8 @@ native void TF2Items_SetFlags(Handle item, int flags);
 /**
  * Sets the new entity classname used for the item's entity.
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @param classname		New classname to use for the entity.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param classname       New classname to use for the entity.
  * @noreturn
  */
 native void TF2Items_SetClassname(Handle item, char[] classname);
@@ -74,8 +74,8 @@ native void TF2Items_SetClassname(Handle item, char[] classname);
  * weapon/hat/item has an unique definition index. Find these out in the
  * game_items.txt
  * 
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @param itemDefIndex	New definition index.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param itemDefIndex    New definition index.
  * @noreturn
  */
 native void TF2Items_SetItemIndex(Handle item, int itemDefIndex);
@@ -84,8 +84,8 @@ native void TF2Items_SetItemIndex(Handle item, int itemDefIndex);
  * Sets the item's quality value, wich determines what color will be used for
  * the item name. Valid values are from 0 to 9.
  * 
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @param quality		New item quality.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param quality         New item quality.
  * @noreturn
  */
 native void TF2Items_SetQuality(Handle item, int quality);
@@ -93,8 +93,8 @@ native void TF2Items_SetQuality(Handle item, int quality);
 /**
  * Sets the item's level value. This value can range from 0 to 127.
  * 
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @param level			New item level.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param level           New item level.
  * @noreturn
  */
 native void TF2Items_SetLevel(Handle item, int level);
@@ -103,8 +103,8 @@ native void TF2Items_SetLevel(Handle item, int level);
  * Sets the number of attributes that will be used on the item. The maximum
  * number of attributes that can be allocated ranges from 0 to 15.
  * 
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @param attributes		Number of attributes.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param attributes      Number of attributes.
  * @noreturn
  */
 native void TF2Items_SetNumAttributes(Handle item, int attributes);
@@ -113,10 +113,10 @@ native void TF2Items_SetNumAttributes(Handle item, int attributes);
  * Setups the given attribute index to use the attribute and values specified
  * with iAttribDefIndex and flValue. Remember the iSlotIndex ranges from 0 to 15.
  * 
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @param slot			The attribute slot index, ranges from 0 to 15.
- * @param attribute		The attribute definition index, as it appears on game_items.txt.
- * @param value			The value assigned to the attribute (how much health, damage, etc.).
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param slot            The attribute slot index, ranges from 0 to 15.
+ * @param attribute       The attribute definition index, as it appears on game_items.txt.
+ * @param value           The value assigned to the attribute (how much health, damage, etc.).
  * @noreturn
  */
 native void TF2Items_SetAttribute(Handle item, int slot, int attribute, float value);
@@ -125,24 +125,24 @@ native void TF2Items_SetAttribute(Handle item, int slot, int attribute, float va
  * Retrieves the flags used to determine what the item will override on the
  * GiveNamedItem call.
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @return				Returns the flags used by the item.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                Returns the flags used by the item.
  */
 native int TF2Items_GetFlags(Handle item);
 
 /**
  * Gets the entity classname we'll use for the item.
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @return				New classname to use for the entity.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                New classname to use for the entity.
  */
 native void TF2Items_GetClassname(Handle item, char[] dest, int size);
 
 /**
  * Gets the new item definition index we'll use to override.
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @return				New definition index.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                New definition index.
  */
 native int TF2Items_GetItemIndex(Handle item); 
 
@@ -151,16 +151,16 @@ native int TF2Items_GetItemIndex(Handle item);
  * the item name. Valid values are from 0 to 9. But if set to 0 and attributes
  * are also changed, this value will be overridden to 9
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @return				New entity quality.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                New entity quality.
  */
 native int TF2Items_GetQuality(Handle item); 
 
 /**
  * Gets the item's level value. This value can range from 0 to 127.
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @return				New entity level.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                New entity level.
  */
 native int TF2Items_GetLevel(Handle item);
 
@@ -168,8 +168,8 @@ native int TF2Items_GetLevel(Handle item);
  * Gets the number of attributes that will be used on the item. The maximum
  * number of attributes that can be allocated ranges from 0 to 15.
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @return				Number of attributes.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                Number of attributes.
  */
 native int TF2Items_GetNumAttributes(Handle item);
 
@@ -177,8 +177,8 @@ native int TF2Items_GetNumAttributes(Handle item);
  * Retrieves the attribute definition index used at the specified index on the
  * item object. Remember the iSlotIndex ranges from 0 to 15.
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @return				The attribute definition index to use.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                The attribute definition index to use.
  */
 native int TF2Items_GetAttributeId(Handle item, int slot);
 
@@ -186,8 +186,8 @@ native int TF2Items_GetAttributeId(Handle item, int slot);
  * Retrieves the value used for the attribute at the specified index on the item
  * object. Remember the iSlotIndex ranges from 0 to 15.
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
- * @return				The attribute value to use.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                The attribute value to use.
  */
 native float TF2Items_GetAttributeValue(Handle item, int slot); 
 
@@ -199,10 +199,10 @@ native float TF2Items_GetAttributeValue(Handle item, int slot);
  * Return Plugin_Handled to stop the item being given to the player.
  * Make sure the client gets atleast one weapon.
  *
- * @param client	Client Index.
- * @param classname		The classname of the entity that will be generated.
- * @param itemDefIndex	Item definition index.
- * @param item			Handle to a TF2Item object wich describes what values will be overriden.
+ * @param client          Client Index.
+ * @param classname       The classname of the entity that will be generated.
+ * @param itemDefIndex    Item definition index.
+ * @param item            Handle to a TF2Item object wich describes what values will be overriden.
  */
 forward Action TF2Items_OnGiveNamedItem(int client, char[] classname, int itemDefIndex, Handle& item);
 

--- a/pawn/tf2items.inc
+++ b/pawn/tf2items.inc
@@ -206,7 +206,7 @@ native float TF2Items_GetAttributeValue(Handle item, int slot);
  */
 forward Action TF2Items_OnGiveNamedItem(int client, char[] classname, int itemDefIndex, Handle& item);
 
-forward int TF2Items_OnGiveNamedItem_Post(int client, char[] classname, int itemDefIndex, int level, int quality, int entity);
+forward void TF2Items_OnGiveNamedItem_Post(int client, char[] classname, int itemDefIndex, int level, int quality, int entity);
 
 /**
  * Do not edit below this line!

--- a/pawn/tf2items.inc
+++ b/pawn/tf2items.inc
@@ -134,9 +134,9 @@ native int TF2Items_GetFlags(Handle item);
  * Gets the entity classname we'll use for the item.
  *
  * @param item            Handle to the TF2Items object that we'll be operating with.
- * @return                New classname to use for the entity.
+ * @return                Size of entity classname string.
  */
-native void TF2Items_GetClassname(Handle item, char[] dest, int size);
+native int TF2Items_GetClassname(Handle item, char[] dest, int size);
 
 /**
  * Gets the new item definition index we'll use to override.
@@ -144,7 +144,7 @@ native void TF2Items_GetClassname(Handle item, char[] dest, int size);
  * @param item            Handle to the TF2Items object that we'll be operating with.
  * @return                New definition index.
  */
-native int TF2Items_GetItemIndex(Handle item); 
+native int TF2Items_GetItemIndex(Handle item);
 
 /**
  * Gets the item's quality value, wich determines what color will be used for

--- a/pawn/tf2items_manager.sp
+++ b/pawn/tf2items_manager.sp
@@ -253,13 +253,13 @@ void ParseItems() {
 	// Create key values object and parse file.
 	BuildPath(Path_SM, buffer, sizeof(buffer), "configs/tf2items.weapons.txt");
 	KeyValues kv = new KeyValues("TF2Items");
-	if (kv.ImportFromFile(buffer) == false) {
+	if (!kv.ImportFromFile(buffer)) {
 		SetFailState("Error, can't read file containing the item list : %s", buffer);
 	}
 
 	// Check the version
 	kv.GetSectionName(buffer, sizeof(buffer));
-	if (StrEqual("custom_weapons_v3", buffer) == false) {
+	if (!StrEqual("custom_weapons_v3", buffer)) {
 		SetFailState("tf2items.weapons.txt structure corrupt or incorrect version: \"%s\"", buffer);
 	}
 

--- a/pawn/tf2items_manager.sp
+++ b/pawn/tf2items_manager.sp
@@ -496,5 +496,5 @@ void DestroyItems() {
  * Checks if a client is valid.
  * -------------------------------------------------------------------------- */
 bool IsValidClient(int client) {
-	return (0 < client <= MaxClients && IsClientConnected(client) && IsClientInGame(client));
+	return (0 < client <= MaxClients) && IsClientInGame(client);
 }

--- a/pawn/tf2items_manager.sp
+++ b/pawn/tf2items_manager.sp
@@ -18,9 +18,9 @@
 //#define DEBUG
 
 // ====[ VARIABLES ]===================================================
-Handle g_hPlayerInfo;
-Handle g_hPlayerArray;
-Handle g_hGlobalSettings;
+StringMap g_hPlayerInfo;
+ArrayList g_hPlayerArray;
+ArrayList g_hGlobalSettings;
 ConVar g_hCvarEnabled;
 ConVar g_hCvarPlayerControlEnabled;
 bool g_bPlayerEnabled[MAXPLAYERS + 1] =  { true, ... };
@@ -45,13 +45,13 @@ public void OnPluginStart() {
 	CreateConVar("tf2items_manager_version", PLUGIN_VERSION, PLUGIN_NAME, FCVAR_SPONLY|FCVAR_REPLICATED|FCVAR_NOTIFY);
 	g_hCvarEnabled = CreateConVar("tf2items_manager", "1", "Enables/disables the manager (0 - Disabled / 1 - Enabled", FCVAR_REPLICATED|FCVAR_NOTIFY);
 	g_hCvarPlayerControlEnabled = CreateConVar("tf2items_manager_playercontrol", "1", "Enables/disables the player's ability to control the manager (0 - Disabled / 1 - Enabled");
-	
+
 	// Register console commands
 	RegAdminCmd("tf2items_manager_reload", CmdReload, ADMFLAG_GENERIC);
-	
+
 	RegConsoleCmd("tf2items_enable", CmdEnable);
 	RegConsoleCmd("tf2items_disable", CmdDisable);
-	
+
 	// Parse the items list
 	ParseItems();
 }
@@ -62,20 +62,22 @@ public void OnPluginStart() {
  * -------------------------------------------------------------------------- */
 public Action TF2Items_OnGiveNamedItem(int client, char[] classname, int itemDefIndex, Handle &override) {
 	// If disabled, use the default values.
-	if (!GetConVarBool(g_hCvarEnabled) || (GetConVarBool(g_hCvarPlayerControlEnabled) && !g_bPlayerEnabled[client]))
+	if (!g_hCvarEnabled.BoolValue || (g_hCvarPlayerControlEnabled.BoolValue && !g_bPlayerEnabled[client])) {
 		return Plugin_Continue;
-	
+	}
+
 	// If another plugin already tryied to override the item, let him go ahead.
-	if (override != null)
+	if (override != null) {
 		return Plugin_Continue; // Plugin_Changed
-	
+	}
+
 	// Find item. If any is found, override the attributes with these.
 	Handle item = FindItem(client, itemDefIndex);
 	if (item != null) {
 		override = item;
 		return Plugin_Changed;
 	}
-	
+
 	// None found, use default values.
 	return Plugin_Continue;
 }
@@ -107,18 +109,20 @@ public void OnClientDisconnect(int client) {
 ** -------------------------------------------------------------------------- */
 public Action CmdReload(int client, int action) {
 	// Fire a message telling about the operation.
-	if (client)
+	if (client) {
 		ReplyToCommand(client, "Reloading items list");
-	else
+	}
+	else {
 		LogMessage("Reloading items list");
-	
+	}
+
 	// Call the ParseItems function.
 	ParseItems();
 	return Plugin_Handled;
 }
 
 public Action CmdEnable(int client, int action) {
-	if (!GetConVarBool(g_hCvarPlayerControlEnabled)) {
+	if (!g_hCvarPlayerControlEnabled.BoolValue) {
 		ReplyToCommand(client, "The server administrator has disabled this command.");
 		return Plugin_Handled;
 	}
@@ -129,11 +133,11 @@ public Action CmdEnable(int client, int action) {
 }
 
 public Action CmdDisable(int client, int action) {
-	if (!GetConVarBool(g_hCvarPlayerControlEnabled)) {
+	if (!g_hCvarPlayerControlEnabled.BoolValue) {
 		ReplyToCommand(client, "The server administrator has disabled this command.");
 		return Plugin_Handled;
 	}
-	
+
 	ReplyToCommand(client, "Disabling TF2Items for you.");
 	g_bPlayerEnabled[client] = false;
 	return Plugin_Handled;
@@ -152,62 +156,70 @@ public Action CmdDisable(int client, int action) {
 
 /* FindItem()
 **
-** Tryies to find a custom item usable by the client.
+** Tries to find a custom item usable by the client.
 ** -------------------------------------------------------------------------- */
 Handle FindItem(int client, int itemDefIndex) {
 	// Check if the player is valid
-	if (!IsValidClient(client))
+	if (!IsValidClient(client)) {
 		return null;
-	
+	}
+
 	// Retrieve the STEAM auth string
 	char auth[64];
 	GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth));
-	
+
 	// Check if it's on the list. If not, try with the global settings.
-	Handle itemArray = null; 
-	GetTrieValue(g_hPlayerInfo, auth, itemArray);
-	
+	ArrayList itemArray = null;
+	g_hPlayerInfo.GetValue(auth, itemArray);
+
 	// Check for each.
 	Handle output;
 	output = FindItemOnArray(client, itemArray, itemDefIndex);
-	if (output == null)
+	if (output == null) {
 		output = FindItemOnArray(client, g_hGlobalSettings, itemDefIndex);
-	
+	}
+
 	// Done
 	return output;
 }
 
 /* FindItemOnArray()
 **
-** 
+**
 ** -------------------------------------------------------------------------- */
-Handle FindItemOnArray(int client, Handle array, int itemDefIndex) {
+Handle FindItemOnArray(int client, ArrayList array, int itemDefIndex) {
 	// Check if the array is valid.
-	if (array == null)
+	if (array == null) {
 		return null;
-		
+	}
+
 	Handle wildcardItem = null;
-	
+
 	// Iterate through each item entry and close the handle.
-	for (int itemEntry = 0; itemEntry < GetArraySize(array); itemEntry++) {
+	for (int itemEntry = 0; itemEntry < array.Length; itemEntry++) {
 		// Retrieve item
-		Handle item = GetArrayCell(array, itemEntry, ARRAY_ITEM);
-		int itemflags = GetArrayCell(array, itemEntry, ARRAY_FLAGS);
-		if (item == null)
+		Handle item = array.Get(itemEntry, ARRAY_ITEM);
+		int itemflags = array.Get(itemEntry, ARRAY_FLAGS);
+		if (item == null) {
 			continue;
-		
-		// Is a wildcard item? If so, store it.
-		if (TF2Items_GetItemIndex(item) == -1 && wildcardItem == null)
-			if (CheckItemUsage(client, itemflags))
-				wildcardItem = item;
-			
-		// Is the item we're looking for? If so return item, but first
-		// check if it's possible due to the 
-		if (TF2Items_GetItemIndex(item) == itemDefIndex)
-			if (CheckItemUsage(client, itemflags))
-				return item;
 		}
-	
+
+		// Is a wildcard item? If so, store it.
+		if (TF2Items_GetItemIndex(item) == -1 && wildcardItem == null) {
+			if (CheckItemUsage(client, itemflags)) {
+				wildcardItem = item;
+			}
+		}
+
+		// Is the item we're looking for? If so return item, but first
+		// check if it's possible due to the
+		if (TF2Items_GetItemIndex(item) == itemDefIndex) {
+			if (CheckItemUsage(client, itemflags)) {
+				return item;
+			}
+		}
+	}
+
 	// Done, returns wildcard item if it exists.
 	return wildcardItem;
 }
@@ -217,14 +229,15 @@ Handle FindItemOnArray(int client, Handle array, int itemDefIndex) {
  * Checks if a client has any of the specified flags.
  * -------------------------------------------------------------------------- */
 bool CheckItemUsage(int client, int flags) {
-	if (flags == 0)
+	if (flags == 0) {
 		return true;
-	
+	}
+
 	int clientFlags = GetUserFlagBits(client);
-	if (clientFlags & ADMFLAG_ROOT)
+	if (clientFlags & ADMFLAG_ROOT) {
 		return true;
-	else 
-		return (clientFlags & flags) != 0;
+	}
+	return (clientFlags & flags) != 0;
 }
 
 /* ParseItems()
@@ -233,204 +246,212 @@ bool CheckItemUsage(int client, int flags) {
  * -------------------------------------------------------------------------- */
 void ParseItems() {
 	char buffer[256], split[16][64];
-	
+
 	// Destroy the current items data.
 	DestroyItems();
-	
+
 	// Create key values object and parse file.
 	BuildPath(Path_SM, buffer, sizeof(buffer), "configs/tf2items.weapons.txt");
-	KeyValues kv = CreateKeyValues("TF2Items");
-	if (FileToKeyValues(kv, buffer) == false)
+	KeyValues kv = new KeyValues("TF2Items");
+	if (kv.ImportFromFile(buffer) == false) {
 		SetFailState("Error, can't read file containing the item list : %s", buffer);
-	
+	}
+
 	// Check the version
-	KvGetSectionName(kv, buffer, sizeof(buffer));
-	if (StrEqual("custom_weapons_v3", buffer) == false)
+	kv.GetSectionName(buffer, sizeof(buffer));
+	if (StrEqual("custom_weapons_v3", buffer) == false) {
 		SetFailState("tf2items.weapons.txt structure corrupt or incorrect version: \"%s\"", buffer);
-	
+	}
+
 	// Create the array and trie to store & access the item information.
-	g_hPlayerArray = CreateArray();
-	g_hPlayerInfo = CreateTrie();
-	
-	#if defined DEBUG
-		LogMessage("Parsing items");
-		LogMessage("{");
-	#endif 
-	
+	g_hPlayerArray = new ArrayList();
+	g_hPlayerInfo = new StringMap();
+
+#if defined DEBUG
+	LogMessage("Parsing items");
+	LogMessage("{");
+#endif
+
 	// Jump into the first subkey and go on.
-	if (KvGotoFirstSubKey(kv)) {
+	if (kv.GotoFirstSubKey()) {
 		do {
 			// Retrieve player information and split into multiple strings.
-			KvGetSectionName(kv, buffer, sizeof(buffer));
+			kv.GetSectionName(buffer, sizeof(buffer));
 			int auths = ExplodeString(buffer, ";", split, 16, 64);
-			
+
 			// Create new array entry and upload to the array.
-			Handle entry = CreateArray(2);
-			PushArrayCell(g_hPlayerArray, entry);
-			
-			#if defined DEBUG
-				LogMessage("  Entry", buffer);
-				LogMessage("  {");
-				LogMessage("    Used by:");
-			#endif
-			
+			ArrayList entry = new ArrayList(2);
+			g_hPlayerArray.Push(entry);
+
+#if defined DEBUG
+			LogMessage("  Entry", buffer);
+			LogMessage("  {");
+			LogMessage("    Used by:");
+#endif
+
 			// Iterate through each player auth strings and make an
 			// entry for each.
 			for (int auth = 0; auth < auths; auth++) {
 				TrimString(split[auth]);
-				SetTrieValue(g_hPlayerInfo, split[auth], entry);
-				
-				#if defined DEBUG
-					LogMessage("    \"%s\"", split[auth]);
-				#endif
+				g_hPlayerInfo.SetValue(split[auth], entry);
+
+#if defined DEBUG
+				LogMessage("    \"%s\"", split[auth]);
+#endif
 			}
-			
-			#if defined DEBUG
-				LogMessage("");
-			#endif
-			
+
+#if defined DEBUG
+			LogMessage("");
+#endif
+
 			// Read all the item entries
 			ParseItemsEntry(kv, entry);
-			
-			#if defined DEBUG
-				LogMessage("  }");
-			#endif
-		}
-		while (KvGotoNextKey(kv));
-			KvGoBack(kv);
+
+#if defined DEBUG
+			LogMessage("  }");
+#endif
+		} while (kv.GotoNextKey());
+		kv.GoBack();
 	}
-	
+
 	// Close key values
 	delete kv;
-	
+
 	// Try to find the global item settings.
-	GetTrieValue(g_hPlayerInfo, "*", g_hGlobalSettings);
-	
+	g_hPlayerInfo.GetValue("*", g_hGlobalSettings);
+
 	// Done.
-	#if defined DEBUG
-		LogMessage("}");
-	#endif
+#if defined DEBUG
+	LogMessage("}");
+#endif
 }
 
 /* ParseItemsEntry()
  *
  * Reads up a particular items entry.
  * -------------------------------------------------------------------------- */
-void ParseItemsEntry(KeyValues kv, Handle entry) {
+void ParseItemsEntry(KeyValues kv, ArrayList entry) {
 	char buffer[64], buffer2[64], split[2][64];
-	
+
 	// Jump into the first subkey.
-	if (KvGotoFirstSubKey(kv)) {
+	if (kv.GotoFirstSubKey()) {
 		do {
 			Handle item = TF2Items_CreateItem(OVERRIDE_ALL);
 			int attrflags = 0;
-			
+
 			// Retrieve item definition index and store.
-			KvGetSectionName(kv, buffer, sizeof(buffer));
-			if (buffer[0] == '*')
+			kv.GetSectionName(buffer, sizeof(buffer));
+			if (buffer[0] == '*') {
 				TF2Items_SetItemIndex(item, -1);
-			else
+			}
+			else {
 				TF2Items_SetItemIndex(item, StringToInt(buffer));
-			
-			#if defined DEBUG
-				LogMessage("    Item: %i", TF2Items_GetItemIndex(item));
-				LogMessage("    {");
-			#endif
-			
+			}
+
+#if defined DEBUG
+			LogMessage("    Item: %i", TF2Items_GetItemIndex(item));
+			LogMessage("    {");
+#endif
+
 			// Retrieve entity level
-			int level = KvGetNum(kv, "level", -1);
+			int level = kv.GetNum("level", -1);
 			if (level != -1) {
 				TF2Items_SetLevel(item, level);
 				attrflags |= OVERRIDE_ITEM_LEVEL;
 			}
-			
-			#if defined DEBUG
-				if (attrflags & OVERRIDE_ITEM_LEVEL)
-					LogMessage("      Level: %i", TF2Items_GetLevel(item));
-			#endif
-			
+
+#if defined DEBUG
+			if (attrflags & OVERRIDE_ITEM_LEVEL) {
+				LogMessage("      Level: %i", TF2Items_GetLevel(item));
+			}
+#endif
+
 			// Retrieve entity quality
-			int quality = KvGetNum(kv, "quality", -1);
+			int quality = kv.GetNum("quality", -1);
 			if (quality != -1) {
 				TF2Items_SetQuality(item, quality);
 				attrflags |= OVERRIDE_ITEM_QUALITY;
 			}
-			
+
 			#if defined DEBUG
-				if (attrflags & OVERRIDE_ITEM_QUALITY)
+				if (attrflags & OVERRIDE_ITEM_QUALITY) {
 					LogMessage("      Quality: %i", TF2Items_GetQuality(item));
+				}
 			#endif
-			
+
 			// Check for attribute preservation key
-			int preserve = KvGetNum(kv, "preserve-attributes", -1);
-			if (preserve == 1)
+			int preserve = kv.GetNum("preserve-attributes", -1);
+			if (preserve == 1) {
 				attrflags |= PRESERVE_ATTRIBUTES;
-			else {
-				preserve = KvGetNum(kv, "preserve_attributes", -1);
-				if (preserve == 1)
-					attrflags |= PRESERVE_ATTRIBUTES;
 			}
-			
-			#if defined DEBUG
-				LogMessage("      Preserve Attributes: %s", (attrflags & PRESERVE_ATTRIBUTES)?"true":"false");
-			#endif
-			
+			else {
+				preserve = kv.GetNum("preserve_attributes", -1);
+				if (preserve == 1) {
+					attrflags |= PRESERVE_ATTRIBUTES;
+				}
+			}
+
+#if defined DEBUG
+			LogMessage("      Preserve Attributes: %s", (attrflags & PRESERVE_ATTRIBUTES)?"true":"false");
+#endif
+
 			// Read all the attributes
 			int attributeCount = 0;
 			for (;;) {
 				// Format the attribute entry name
 				Format(buffer, sizeof(buffer), "%i", attributeCount+1);
-				
+
 				// Try to read the attribute
-				KvGetString(kv, buffer, buffer2, sizeof(buffer2));
-				
+				kv.GetString(buffer, buffer2, sizeof(buffer2));
+
 				// If not found, break.
-				if (buffer2[0] == '\0') break;
-				
+				if (buffer2[0] == '\0') {
+					break;
+				}
+
 				// Split the information in two buffers
 				ExplodeString(buffer2, ";", split, 2, 64);
 				int attribute = StringToInt(split[0]);
 				float value = StringToFloat(split[1]);
-				
+
 				// Attribute found, set information.
 				TF2Items_SetAttribute(item, attributeCount, attribute, value);
-				
-				#if defined DEBUG
-					LogMessage("      Attribute[%i] : %i / %f",
-						attributeCount,
-						TF2Items_GetAttributeId(item, attributeCount),
-						TF2Items_GetAttributeValue(item, attributeCount)
-					);
-				#endif
-				
+
+#if defined DEBUG
+				LogMessage("      Attribute[%i] : %i / %f",
+					attributeCount,
+					TF2Items_GetAttributeId(item, attributeCount),
+					TF2Items_GetAttributeValue(item, attributeCount)
+				);
+#endif
+
 				// Increase attribute count and continue.
 				attributeCount++;
 			}
-			
+
 			// Done, set attribute count and upload.
 			if (attributeCount != 0) {
 				TF2Items_SetNumAttributes(item, attributeCount);
 				attrflags |= OVERRIDE_ATTRIBUTES;
 			}
-			
+
 			// Retrieve the admin flags
-			KvGetString(kv, "admin-flags", buffer, sizeof(buffer), "");
+			kv.GetString("admin-flags", buffer, sizeof(buffer), "");
 			int flags = ReadFlagString(buffer);
-			
+
 			// Set flags and upload.
 			TF2Items_SetFlags(item, attrflags);
-			PushArrayCell(entry, 0);
-			SetArrayCell(entry, GetArraySize(entry)-1, item, ARRAY_ITEM);
-			SetArrayCell(entry, GetArraySize(entry)-1, flags, ARRAY_FLAGS);
-			
-			#if defined DEBUG
-				LogMessage("      Flags: %05b", TF2Items_GetFlags(item));
-				LogMessage("      Admin: %s", ((flags == 0)? "(none)":buffer));
-				LogMessage("    }");
-			#endif
-		}
-		while (KvGotoNextKey(kv));
-			KvGoBack(kv);
+			entry.Push(0);
+			entry.Set(entry.Length-1, item, ARRAY_ITEM);
+			entry.Set(entry.Length-1, flags, ARRAY_FLAGS);
+
+#if defined DEBUG
+			LogMessage("      Flags: %05b", TF2Items_GetFlags(item));
+			LogMessage("      Admin: %s", ((flags == 0)? "(none)":buffer));
+			LogMessage("    }");
+#endif
+		} while (kv.GotoNextKey());
+		kv.GoBack();
 	}
 }
 
@@ -442,29 +463,30 @@ void DestroyItems() {
 	if (g_hPlayerArray != null) {
 		// Iterate through each player and retrieve the internal
 		// weapon list.
-		for (int entry = 0; entry < GetArraySize(g_hPlayerArray); entry++) {
+		for (int entry = 0; entry < g_hPlayerArray.Length; entry++) {
 			// Retrieve the item array.
-			Handle itemArray = GetArrayCell(g_hPlayerArray, entry);
-			if (itemArray == null)
+			ArrayList itemArray = g_hPlayerArray.Get(entry);
+			if (itemArray == null) {
 				continue;
-			
+			}
+
 			// Iterate through each item entry and close the handle.
-			for (int itemEntry = 0; itemEntry < GetArraySize(itemArray); itemEntry++) {
+			for (int itemEntry = 0; itemEntry < itemArray.Length; itemEntry++) {
 				// Retrieve item
-				Handle item = GetArrayCell(itemArray, itemEntry);
-				
+				Handle item = itemArray.Get(itemEntry);
+
 				// Close handle
 				delete item;
 			}
 		}
-		
+
 		// Done, free array
 		delete g_hPlayerArray;
 	}
-	
+
 	// Free player trie
 	delete g_hPlayerInfo;
-	
+
 	// Done
 	g_hGlobalSettings = null;
 }
@@ -474,9 +496,5 @@ void DestroyItems() {
  * Checks if a client is valid.
  * -------------------------------------------------------------------------- */
 bool IsValidClient(int client) {
-	if (client < 1 || client > MaxClients)
-		return false;
-	if (!IsClientConnected(client))
-		return false;
-	return IsClientInGame(client);
+	return (0 < client <= MaxClients && IsClientConnected(client) && IsClientInGame(client));
 }


### PR DESCRIPTION
Fixes return on TF2Items_GetClassname, which should be int.
Updates Handle datatypes to their methodmap (ArrayList, StringMap, etc).
Include file indentation changed from tabs to spaces for consistency.
Edited formatting for readability (braces, indents).