### PR TITLE
Fix ret values

### DIFF
--- a/pawn/tf2items.inc
+++ b/pawn/tf2items.inc
@@ -34,9 +34,9 @@
  * so please make sure you fill out everything: Classname, item definition index,
  * quality, level and attributes.
  * 
- * @param client    Client that the item will be generated for.
- * @param item      Handle to the TF2Items object that we'll be operating with.
- * @return          Entity index of the newly created item.
+ * @param client          Client that the item will be generated for.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                Entity index of the newly created item.
  */
 native int TF2Items_GiveNamedItem(int client, Handle item);
 

--- a/pawn/tf2items.inc
+++ b/pawn/tf2items.inc
@@ -134,9 +134,9 @@ native int TF2Items_GetFlags(Handle item);
  * Gets the entity classname we'll use for the item.
  *
  * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			New classname to use for the entity.
+ * @return		Size of entity classname string
  */
-native void TF2Items_GetClassname(Handle item, char[] dest, int size);
+native int TF2Items_GetClassname(Handle item, char[] dest, int size);
 
 /**
  * Gets the new item definition index we'll use to override.
@@ -206,7 +206,7 @@ native float TF2Items_GetAttributeValue(Handle item, int slot);
  */
 forward Action TF2Items_OnGiveNamedItem(int client, char[] classname, int itemDefIndex, Handle &item);
 
-forward int TF2Items_OnGiveNamedItem_Post(int client, char[] classname, int itemDefIndex, int level, int quality, int entity);
+forward void TF2Items_OnGiveNamedItem_Post(int client, char[] classname, int itemDefIndex, int level, int quality, int entity);
 
 /**
  * Do not edit below this line!
@@ -226,30 +226,30 @@ public Extension __ext_tf2items =
 /**
 * I'll just leave this here...
 * 
-* _(º< _(º< _(º< _(º< _(º< _(º< _(º< _(º< _(º< 
+* _(Âº< _(Âº< _(Âº< _(Âº< _(Âº< _(Âº< _(Âº< _(Âº< _(Âº< 
 * \__) \__) \__) \__) \__) \__) \__) \__) \__) 
 *                     .  .
 *                    // //  __
-*         __  ______||_//_.´.´
-*       _/__`´            ¯ `
+*         __  ______||_//_.Â´.Â´
+*       _/__`Â´            Â¯ `
 *      /  / _          _     \
-*     /  /( · )      ( · )    |
-*    /  |   ¯     __   ¯    _/\/|
-*   |    \  ___.-´  `-.___  \   /
-*    \    \(     ` ´      `)|   \
+*     /  /( Â· )      ( Â· )    |
+*    /  |   Â¯     __   Â¯    _/\/|
+*   |    \  ___.-Â´  `-.___  \   /
+*    \    \(     ` Â´      `)|   \
 *     \     )              //     \
 *      \/  /              | |     |
 *     /   /               | |     |
-*    ·   |                |  \___/
+*    Â·   |                |  \___/
 *    |    \_            _/      \  ____
-*    ·      `----------´         |´    \
-*     \                         /    _·´
-*      \                       /  _-´ 
-*        `-._               _·´-´
-*        _.-´`---________--´ \ 
-*       ´-.-. _--·   / .   ._ \
-*            ´       `´ `·´  `´
-* >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ 
+*    Â·      `----------Â´         |Â´    \
+*     \                         /    _Â·Â´
+*      \                       /  _-Â´ 
+*        `-._               _Â·Â´-Â´
+*        _.-Â´`---________--Â´ \ 
+*       Â´-.-. _--Â·   / .   ._ \
+*            Â´       `Â´ `Â·Â´  `Â´
+* >Âº)_ >Âº)_ >Âº)_ >Âº)_ >Âº)_ >Âº)_ >Âº)_ >Âº)_ >Âº)_ 
 * (__/ (__/ (__/ (__/ (__/ (__/ (__/ (__/ (__/ 
 * 
 */

--- a/pawn/tf2items.inc
+++ b/pawn/tf2items.inc
@@ -54,7 +54,7 @@ native Handle TF2Items_CreateItem(int flags);
  * Sets the flags to determine what the item will override on the GiveNamedItem.
  * Use the OVERRIDE_ defines to set what you will be changing.
  *
- * @param item			Handle to the TF2Items object that we'll be operating with.
+ * @param item          Handle to the TF2Items object that we'll be operating with.
  * @param flags		Flags used to specify what to override.
  * @noreturn
  */
@@ -134,7 +134,7 @@ native int TF2Items_GetFlags(Handle item);
  * Gets the entity classname we'll use for the item.
  *
  * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return		Size of entity classname string
+ * @return			Size of entity classname string
  */
 native int TF2Items_GetClassname(Handle item, char[] dest, int size);
 

--- a/pawn/tf2items.inc
+++ b/pawn/tf2items.inc
@@ -6,15 +6,15 @@
 #include <tf2>
 
 // ====[ CONSTANTS ]===========================================================
-#define OVERRIDE_CLASSNAME		(1 << 0)	// Item will override the entity's classname.
-#define OVERRIDE_ITEM_DEF			(1 << 1)	// Item will override the item's definition index.
-#define OVERRIDE_ITEM_LEVEL		(1 << 2)	// Item will override the entity's level.
-#define OVERRIDE_ITEM_QUALITY		(1 << 3)	// Item will override the entity's quality.
-#define OVERRIDE_ATTRIBUTES		(1 << 4)	// Item will override the attributes for the item with the given ones.
-#define OVERRIDE_ALL				(0b11111)	// Magically enables all the other flags.
+#define OVERRIDE_CLASSNAME      (1 << 0)    // Item will override the entity's classname.
+#define OVERRIDE_ITEM_DEF       (1 << 1)    // Item will override the item's definition index.
+#define OVERRIDE_ITEM_LEVEL     (1 << 2)    // Item will override the entity's level.
+#define OVERRIDE_ITEM_QUALITY   (1 << 3)    // Item will override the entity's quality.
+#define OVERRIDE_ATTRIBUTES     (1 << 4)    // Item will override the attributes for the item with the given ones.
+#define OVERRIDE_ALL            (0b11111)   // Magically enables all the other flags.
 
-#define PRESERVE_ATTRIBUTES		(1 << 5)
-#define FORCE_GENERATION		(1 << 6)
+#define PRESERVE_ATTRIBUTES     (1 << 5)
+#define FORCE_GENERATION        (1 << 6)
 
 // ====[ NATIVES ]=============================================================
 
@@ -34,9 +34,9 @@
  * so please make sure you fill out everything: Classname, item definition index,
  * quality, level and attributes.
  * 
- * @param client	Client that the item will be generated for.
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			Entity index of the newly created item.
+ * @param client    Client that the item will be generated for.
+ * @param item      Handle to the TF2Items object that we'll be operating with.
+ * @return          Entity index of the newly created item.
  */
 native int TF2Items_GiveNamedItem(int client, Handle item);
 
@@ -45,8 +45,8 @@ native int TF2Items_GiveNamedItem(int client, Handle item);
  * item before it's given to the client, or to create a new completely new one
  * with GiveNamedItem. Remember to free the object with CloseHandle()
  *
- * @param flags		Flags used to specify what to override.
- * @return				Handle to the TFItems object.
+ * @param flags           Flags used to specify what to override.
+ * @return                Handle to the TFItems object.
  */
 native Handle TF2Items_CreateItem(int flags);
 
@@ -54,8 +54,8 @@ native Handle TF2Items_CreateItem(int flags);
  * Sets the flags to determine what the item will override on the GiveNamedItem.
  * Use the OVERRIDE_ defines to set what you will be changing.
  *
- * @param item          Handle to the TF2Items object that we'll be operating with.
- * @param flags		Flags used to specify what to override.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param flags           Flags used to specify what to override.
  * @noreturn
  */
 native void TF2Items_SetFlags(Handle item, int flags);
@@ -63,8 +63,8 @@ native void TF2Items_SetFlags(Handle item, int flags);
 /**
  * Sets the new entity classname used for the item's entity.
  *
- * @param item				Handle to the TF2Items object that we'll be operating with.
- * @param classname		New classname to use for the entity.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param classname       New classname to use for the entity.
  * @noreturn
  */
 native void TF2Items_SetClassname(Handle item, char[] classname);
@@ -74,8 +74,8 @@ native void TF2Items_SetClassname(Handle item, char[] classname);
  * weapon/hat/item has an unique definition index. Find these out in the
  * game_items.txt
  * 
- * @param item				Handle to the TF2Items object that we'll be operating with.
- * @param itemDefIndex		New definition index.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param itemDefIndex    New definition index.
  * @noreturn
  */
 native void TF2Items_SetItemIndex(Handle item, int itemDefIndex);
@@ -84,8 +84,8 @@ native void TF2Items_SetItemIndex(Handle item, int itemDefIndex);
  * Sets the item's quality value, wich determines what color will be used for
  * the item name. Valid values are from 0 to 9.
  * 
- * @param item					Handle to the TF2Items object that we'll be operating with.
- * @param quality		New item quality.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param quality         New item quality.
  * @noreturn
  */
 native void TF2Items_SetQuality(Handle item, int quality);
@@ -93,8 +93,8 @@ native void TF2Items_SetQuality(Handle item, int quality);
 /**
  * Sets the item's level value. This value can range from 0 to 127.
  * 
- * @param item				Handle to the TF2Items object that we'll be operating with.
- * @param level		New item level.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param level           New item level.
  * @noreturn
  */
 native void TF2Items_SetLevel(Handle item, int level);
@@ -103,8 +103,8 @@ native void TF2Items_SetLevel(Handle item, int level);
  * Sets the number of attributes that will be used on the item. The maximum
  * number of attributes that can be allocated ranges from 0 to 15.
  * 
- * @param item					Handle to the TF2Items object that we'll be operating with.
- * @param attributes		Number of attributes.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param attributes      Number of attributes.
  * @noreturn
  */
 native void TF2Items_SetNumAttributes(Handle item, int attributes);
@@ -113,10 +113,10 @@ native void TF2Items_SetNumAttributes(Handle item, int attributes);
  * Setups the given attribute index to use the attribute and values specified
  * with iAttribDefIndex and flValue. Remember the iSlotIndex ranges from 0 to 15.
  * 
- * @param item					Handle to the TF2Items object that we'll be operating with.
- * @param slot			The attribute slot index, ranges from 0 to 15.
- * @param attribute		The attribute definition index, as it appears on game_items.txt.
- * @param value				The value assigned to the attribute (how much health, damage, etc.).
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @param slot            The attribute slot index, ranges from 0 to 15.
+ * @param attribute       The attribute definition index, as it appears on game_items.txt.
+ * @param value           The value assigned to the attribute (how much health, damage, etc.).
  * @noreturn
  */
 native void TF2Items_SetAttribute(Handle item, int slot, int attribute, float value);
@@ -125,24 +125,24 @@ native void TF2Items_SetAttribute(Handle item, int slot, int attribute, float va
  * Retrieves the flags used to determine what the item will override on the
  * GiveNamedItem call.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			Returns the flags used by the item.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                Returns the flags used by the item.
  */
 native int TF2Items_GetFlags(Handle item);
 
 /**
  * Gets the entity classname we'll use for the item.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			Size of entity classname string
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                Size of entity classname string
  */
 native int TF2Items_GetClassname(Handle item, char[] dest, int size);
 
 /**
  * Gets the new item definition index we'll use to override.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			New definition index.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                New definition index.
  */
 native int TF2Items_GetItemIndex(Handle item); 
 
@@ -151,16 +151,16 @@ native int TF2Items_GetItemIndex(Handle item);
  * the item name. Valid values are from 0 to 9. But if set to 0 and attributes
  * are also changed, this value will be overridden to 9
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			New entity quality.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                New entity quality.
  */
 native int TF2Items_GetQuality(Handle item); 
 
 /**
  * Gets the item's level value. This value can range from 0 to 127.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			New entity level.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                New entity level.
  */
 native int TF2Items_GetLevel(Handle item);
 
@@ -168,8 +168,8 @@ native int TF2Items_GetLevel(Handle item);
  * Gets the number of attributes that will be used on the item. The maximum
  * number of attributes that can be allocated ranges from 0 to 15.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			Number of attributes.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                Number of attributes.
  */
 native int TF2Items_GetNumAttributes(Handle item);
 
@@ -177,8 +177,8 @@ native int TF2Items_GetNumAttributes(Handle item);
  * Retrieves the attribute definition index used at the specified index on the
  * item object. Remember the iSlotIndex ranges from 0 to 15.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			The attribute definition index to use.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                The attribute definition index to use.
  */
 native int TF2Items_GetAttributeId(Handle item, int slot);
 
@@ -186,8 +186,8 @@ native int TF2Items_GetAttributeId(Handle item, int slot);
  * Retrieves the value used for the attribute at the specified index on the item
  * object. Remember the iSlotIndex ranges from 0 to 15.
  *
- * @param item		Handle to the TF2Items object that we'll be operating with.
- * @return			The attribute value to use.
+ * @param item            Handle to the TF2Items object that we'll be operating with.
+ * @return                The attribute value to use.
  */
 native float TF2Items_GetAttributeValue(Handle item, int slot); 
 
@@ -199,10 +199,10 @@ native float TF2Items_GetAttributeValue(Handle item, int slot);
  * Return Plugin_Handled to stop the item being given to the player.
  * Make sure the client gets atleast one weapon.
  *
- * @param client				Client Index.
- * @param classname				The classname of the entity that will be generated.
- * @param itemDefIndex	Item definition index.
- * @param item					Handle to a TF2Item object wich describes what values will be overriden.
+ * @param client          Client Index.
+ * @param classname       The classname of the entity that will be generated.
+ * @param itemDefIndex    Item definition index.
+ * @param item            Handle to a TF2Item object wich describes what values will be overriden.
  */
 forward Action TF2Items_OnGiveNamedItem(int client, char[] classname, int itemDefIndex, Handle &item);
 

--- a/pawn/tf2items.inc
+++ b/pawn/tf2items.inc
@@ -56,7 +56,6 @@ native Handle TF2Items_CreateItem(int flags);
  *
  * @param item            Handle to the TF2Items object that we'll be operating with.
  * @param flags           Flags used to specify what to override.
- * @noreturn
  */
 native void TF2Items_SetFlags(Handle item, int flags);
 
@@ -65,7 +64,6 @@ native void TF2Items_SetFlags(Handle item, int flags);
  *
  * @param item            Handle to the TF2Items object that we'll be operating with.
  * @param classname       New classname to use for the entity.
- * @noreturn
  */
 native void TF2Items_SetClassname(Handle item, char[] classname);
 
@@ -76,7 +74,6 @@ native void TF2Items_SetClassname(Handle item, char[] classname);
  * 
  * @param item            Handle to the TF2Items object that we'll be operating with.
  * @param itemDefIndex    New definition index.
- * @noreturn
  */
 native void TF2Items_SetItemIndex(Handle item, int itemDefIndex);
 
@@ -86,7 +83,6 @@ native void TF2Items_SetItemIndex(Handle item, int itemDefIndex);
  * 
  * @param item            Handle to the TF2Items object that we'll be operating with.
  * @param quality         New item quality.
- * @noreturn
  */
 native void TF2Items_SetQuality(Handle item, int quality);
 
@@ -95,7 +91,6 @@ native void TF2Items_SetQuality(Handle item, int quality);
  * 
  * @param item            Handle to the TF2Items object that we'll be operating with.
  * @param level           New item level.
- * @noreturn
  */
 native void TF2Items_SetLevel(Handle item, int level);
 
@@ -105,7 +100,6 @@ native void TF2Items_SetLevel(Handle item, int level);
  * 
  * @param item            Handle to the TF2Items object that we'll be operating with.
  * @param attributes      Number of attributes.
- * @noreturn
  */
 native void TF2Items_SetNumAttributes(Handle item, int attributes);
 
@@ -117,7 +111,6 @@ native void TF2Items_SetNumAttributes(Handle item, int attributes);
  * @param slot            The attribute slot index, ranges from 0 to 15.
  * @param attribute       The attribute definition index, as it appears on game_items.txt.
  * @param value           The value assigned to the attribute (how much health, damage, etc.).
- * @noreturn
  */
 native void TF2Items_SetAttribute(Handle item, int slot, int attribute, float value);
 


### PR DESCRIPTION
Since my bigger PR is ignored, this is a small PR to fix ret vals on `TF2Items_OnGiveNamedItem_Post` forward and `TF2Items_GetClassname` native

This also makes indentation on documentation uniform by using spaces instead of tabs because it's been bugging me forever.