### PR TITLE
Update gamedata for x64

### DIFF
--- a/tf2.items.txt
+++ b/tf2.items.txt
@@ -6,9 +6,10 @@
 		{
 			"GiveNamedItem"
 			{
-				"windows"	"487"
-				"linux"	"494"
-				"mac"	"494"
+				"windows64" "487"
+				"windows"   "487"
+				"linux"     "494"
+				"linux64"   "494"
 			}
 		}
 	}


### PR DESCRIPTION
Hey @psychonic ! I still plan to eventually fix this ext for x64, but in the meantime I suggest we update the gamedata now. The SM updater overwrites local changes, and its a bit annoying setting up custom for it :3 

Some people have also forked? tf2items, but their gamedata is getting overwritten. So let's help them too.